### PR TITLE
feat(data_center): 完成 reload() 方法，支援資料重新整理

### DIFF
--- a/data/data_facade.py
+++ b/data/data_facade.py
@@ -15,6 +15,11 @@ class DataFacade:
         self._build_features()
         self._load_q_table()
 
+    def reload(self):
+        """重新讀取資料並刷新快取"""
+        self._load_game_log()
+        self._build_features()
+        self._load_q_table()
     def _build_features(self):
         """加工特徵資料，快取起來"""
         if self._game_log is not None:

--- a/tests/test_data_facade.py
+++ b/tests/test_data_facade.py
@@ -21,5 +21,21 @@ def test_load_game_log():
     assert 'test_col' not in features2.columns
 
     print("✅ 測試通過：get_features 正常提供副本且安全！")
+        # 修改原本快取
+    old_game_log = facade.get_game_log()
+    old_features = facade.get_features()
+
+    # 模擬外部更新資料（手動 reload）
+    facade.reload()
+
+    new_game_log = facade.get_game_log()
+    new_features = facade.get_features()
+
+    # 測試 reload 是否有成功刷新資料（可以簡單用 shape 或 id 來確認）
+    assert id(old_game_log) != id(new_game_log)
+    assert id(old_features) != id(new_features)
+
+    print("✅ 測試通過：reload 成功刷新資料！")
+
 if __name__ == "__main__":
     test_load_game_log()


### PR DESCRIPTION
## 變更內容
- 實作 DataFacade 的 reload() 方法
- 支援 game_log, features, q_table 資料刷新
- 撰寫小型測試，確認 reload 更新成功

## 關聯 Issue
Closes #28 

## 測試方式
- 修改原資料快取
- 呼叫 reload()
- 取得的新資料應為重新讀取的新版本
