### PR TITLE
feat: 加入資料讀取的中間層

### DIFF
--- a/data/data_facade.py
+++ b/data/data_facade.py
@@ -1,41 +1,84 @@
-import pickle
+# data/data_facade.py
+
 import pandas as pd
-from data.feature_builder import FeatureBuilder
+import pickle
 import json
-from datetime import datetime
-from data.data_errors import DataLoadError, DataFormatError
 from pathlib import Path
+from datetime import datetime
+from data.feature_builder import FeatureBuilder
+from data.data_errors import DataLoadError, DataFormatError
 
 class DataFacade:
-    def __init__(self, path_game_log: str, path_q_table: str):
-        """初始化資料中心，讀取 game_log 與 q_table，建構特徵資料"""
-        self._on_data_updated = []  # 資料更新後的通知 callback 列表
+    def __init__(self, root: Path):
+        """初始化資料中心，設定資料根目錄"""
+        self.root = Path(root)
+        self._cache: dict[str, object] = {}
+        self._on_data_updated = []  # 資料更新通知 callback 列表（目前保留可擴充）
 
-        self.path_game_log = path_game_log
-        self.path_q_table = path_q_table
-        self._game_log = None
-        self._features = None
-        self._q_table = None
-        self._cache = {}
+    # --- 對外資料讀取介面 ---
+    def game_log(self) -> pd.DataFrame:
+        """讀取 game_log"""
+        return self._load_csv("raw/game_log.csv")
 
-        self._load_game_log()
-        self._build_features()
-        self._load_q_table()
+    def q_table(self, model_name: str = "q_model_0425_2023.pkl") -> pd.DataFrame:
+        """讀取指定模型的 Q-Table"""
+        return self._load_pickle(f"models/{model_name}")
+
     def list_models(self) -> list[str]:
-        """列出 models 資料夾下所有 .pkl 檔案名稱"""
-        model_dir = Path("./data/models/")
-        print(f"🔍 掃描資料夾: {model_dir}")
-
+        """列出 models 資料夾下所有 .pkl 模型檔案"""
+        model_dir = self.root / "models"
         if not model_dir.exists():
             return []
-        
-        # 用 glob 抓所有 .pkl 檔案
         pkl_files = list(model_dir.glob("q_model_*.pkl"))
-        models = [pkl_file.stem for pkl_file in pkl_files]  # 注意要取 .stem（檔名不含副檔名）
+        models = [pkl_file.stem for pkl_file in pkl_files]
         return sorted(models)
 
+    def append_game_log(self, new_entry: dict):
+        """追加一筆新下注資料到 game_log.csv（不自動 reload，由 Session 控）"""
+        if not isinstance(new_entry, dict):
+            raise TypeError("新資料必須是 dict 格式")
+
+        required_fields = ['timestamp', 'round', 'bet', 'winner']
+        for field in required_fields:
+            if field not in new_entry:
+                raise DataFormatError(f"新資料缺少必要欄位: {field}")
+
+        if isinstance(new_entry['bet'], list):
+            new_entry['bet'] = json.dumps(new_entry['bet'])
+        if isinstance(new_entry['timestamp'], datetime):
+            new_entry['timestamp'] = new_entry['timestamp'].strftime("%Y-%m-%d %H:%M:%S")
+
+        df_new = pd.DataFrame([new_entry])
+
+        try:
+            df_new.to_csv(self.root / "raw/game_log.csv", mode='a', header=False, index=False)
+            print("✅ 成功追加新資料到 game_log.csv")
+        except Exception as e:
+            raise DataLoadError(f"無法追加資料到 game_log.csv: {e}")
+
+    # --- 資料加工（FeatureBuilder）---
+    def build_features(self, df_game_log: pd.DataFrame) -> pd.DataFrame:
+        """從 game_log 建構特徵欄位"""
+        required_columns = ['timestamp', 'round', 'bet', 'winner']
+        for col in required_columns:
+            if col not in df_game_log.columns:
+                raise DataFormatError(f"game_log 缺少必要欄位：{col}")
+
+        features = FeatureBuilder.build_features(df_game_log)
+        return features
+
+    # --- 快取操作 ---
+    def refresh_cache(self, key: str):
+        """手動清除某個 key 的 cache"""
+        self._cache.pop(key, None)
+
+    def clear_all_cache(self):
+        """清空所有 cache"""
+        self._cache.clear()
+
+    # --- 資料更新通知（目前保留，可用於未來 UI 主動更新）---
     def register_on_data_updated(self, callback: callable):
-        """外部模組可以註冊資料更新完成時要通知的函數"""
+        """註冊資料更新通知的 callback"""
         if callable(callback):
             self._on_data_updated.append(callback)
         else:
@@ -49,93 +92,17 @@ class DataFacade:
             except Exception as e:
                 print(f"[Error] 通知資料更新失敗: {e}")
 
-    def reload(self):
-        """重新讀取資料並刷新快取（game_log, features, q_table）"""
-        self._load_game_log()
-        self._build_features()
-        self._load_q_table()
-        self._notify_data_updated()
+    # --- 內部通用私有方法 ---
+    def _load_csv(self, rel_path: str) -> pd.DataFrame:
+        """從 cache 或磁碟讀取 CSV 檔"""
+        if rel_path not in self._cache:
+            self._cache[rel_path] = pd.read_csv(self.root / rel_path)
+        return self._cache[rel_path]
 
-    def _build_features(self):
-        """加工特徵資料，快取起來"""
-        if self._game_log is None:
-            raise DataLoadError("尚未載入 game_log 資料，無法建構 features。")
-        
-        # 檢查必要欄位是否存在
-        required_columns = ['timestamp', 'round', 'bet', 'winner']
-        for col in required_columns:
-            if col not in self._game_log.columns:
-                raise DataFormatError(f"game_log 缺少必要欄位：{col}")
-
-        self._features = FeatureBuilder.build_features(self._game_log)
-
-    def _load_game_log(self):
-        """從 CSV 讀取 game_log 並快取"""
-        try:
-            self._game_log = pd.read_csv(self.path_game_log)
-        except FileNotFoundError:
-            raise DataLoadError(f"找不到 game_log 檔案：{self.path_game_log}")
-        except Exception as e:
-            raise DataLoadError(f"讀取 game_log 時發生錯誤：{e}")
-
-    def _load_q_table(self):
-        """從 pickle 檔案讀取 q_table 並快取"""
-        try:
-            with open(self.path_q_table, "rb") as f:
-                self._q_table = pickle.load(f)
-        except FileNotFoundError:
-            raise DataLoadError(f"找不到 q_table 檔案：{self.path_q_table}")
-        except Exception as e:
-            raise DataLoadError(f"讀取 q_table 時發生錯誤：{e}")
-
-    def get_features(self):
-        """取得特徵資料的副本（防止外部污染）"""
-        if self._features is not None:
-            return self._features.copy()
-        else:
-            raise DataLoadError("尚未建構 features 資料！")
-
-    def get_game_log(self):
-        """取得 game_log 的副本"""
-        if self._game_log is not None:
-            return self._game_log.copy()
-        else:
-            raise DataLoadError("尚未載入 game_log 資料！")
-
-    def get_q_table(self):
-        """取得 q_table 的副本（DataFrame）或直接回傳（dict）"""
-        if self._q_table is not None:
-            if hasattr(self._q_table, "copy"):
-                return self._q_table.copy()
-            return self._q_table
-        else:
-            raise DataLoadError("尚未載入 q_table 資料！")
-
-    def append_game_log(self, new_entry: dict, auto_reload: bool = True):
-        """追加一筆新下注資料到 game_log.csv，可選擇是否自動刷新快取"""
-        if not isinstance(new_entry, dict):
-            raise TypeError("新資料必須是 dict 格式")
-
-        required_fields = ['timestamp', 'round', 'bet', 'winner']
-        for field in required_fields:
-            if field not in new_entry:
-                raise DataFormatError(f"新資料缺少必要欄位: {field}")
-
-        # 強制 bet 轉成 JSON 字串格式
-        if isinstance(new_entry['bet'], list):
-            new_entry['bet'] = json.dumps(new_entry['bet'])
-
-        # 強制 timestamp 轉成標準字串格式
-        if isinstance(new_entry['timestamp'], datetime):
-            new_entry['timestamp'] = new_entry['timestamp'].strftime("%Y-%m-%d %H:%M:%S")
-
-        df_new = pd.DataFrame([new_entry])
-
-        try:
-            df_new.to_csv(self.path_game_log, mode='a', header=False, index=False)
-            print("✅ 成功追加新資料到 game_log.csv")
-            if auto_reload:
-                self.reload()
-        except Exception as e:
-            raise DataLoadError(f"無法追加資料到 game_log.csv: {e}")
+    def _load_pickle(self, rel_path: str):
+        """從 cache 或磁碟讀取 pickle 檔"""
+        if rel_path not in self._cache:
+            with open(self.root / rel_path, "rb") as f:
+                self._cache[rel_path] = pickle.load(f)
+        return self._cache[rel_path]
 

--- a/data/global_data.py
+++ b/data/global_data.py
@@ -3,5 +3,38 @@ from data.data_facade import DataFacade
 from data.config_loader import load_config
 from pathlib import Path
 
-DATA_FACADE = DataFacade("data/raw/game_log.csv",'data/models/q_model_0425_2023.pkl')
+DATA_FACADE = DataFacade(Path("./data"))
 CONFIG = load_config()
+
+class Session:
+    _cache = {}
+
+    @classmethod
+    def get(cls, key: str, **kwargs):
+        """取得 session 中的資料"""
+        if key not in cls._cache:
+            if key == "game_log":
+                cls._cache[key] = DATA_FACADE.game_log()
+            elif key == "q_table":
+                model_name = kwargs.get("model_name", CONFIG.get("default_model", "q_model_0425_2023.pkl"))
+                cls._cache[key] = DATA_FACADE.q_table(model_name)
+            else:
+                raise KeyError(f"未知資料類型 {key}")
+        return cls._cache[key]
+
+    @classmethod
+    def refresh(cls, key: str, **kwargs):
+        """強制刷新 session 中的資料"""
+        if key == "game_log":
+            cls._cache[key] = DATA_FACADE.game_log()
+        elif key == "q_table":
+            model_name = kwargs.get("model_name", CONFIG.get("default_model", "q_model_0425_2023.pkl"))
+            cls._cache[key] = DATA_FACADE.q_table(model_name)
+        else:
+            raise KeyError(f"未知資料類型 {key}")
+
+    @classmethod
+    def clear_all(cls):
+        """清除全部 session cache（可選功能）"""
+        cls._cache.clear()
+


### PR DESCRIPTION
    - 讓系統更有彈性
    ## 📋 變更內容
- 重構 `data/data_facade.py`：
  - 移除原本內建的 `_game_log`, `_q_table`, `_features` 快取
  - 改為統一由 `_load_csv` / `_load_pickle` 提供資料
  - 支援動態列出模型 (`list_models`)
  - 新增 `append_game_log()` 方法，供外部追加資料
- 新增 `Session` 中間層 (`data/global_data.py`)：
  - 提供 `Session.get(key)` 取得快取資料
  - 提供 `Session.refresh(key)` 強制刷新指定資料
  - 初期支援 `"game_log"`, `"q_table"` 兩種資料
- 建立測試檔案：
  - `tests/test_data_facade.py` 測試 DataFacade 功能
  - `tests/test_session.py` 測試 Session 功能

---

## 🎯 變更動機
- 過去各模組直接呼叫 DataFacade，容易造成記憶體浪費（每次都複製一份資料）
- 讀取 game_log / q_table 時沒有統一快取策略，資料一致性難以保證
- 透過建立 `Session` 中間層，統一管理快取資料，提升系統穩定性與效能
- 為後續系統擴充（如 fuzzy_policy、風險管理）打下穩固基礎

---

## 🧪 測試結果
- ✅ 成功讀取 game_log（DataFrame）
- ✅ 成功讀取 q_table（dict）
- ✅ 成功追加新資料至 game_log.csv
- ✅ 成功刷新 Session 快取
- ✅ 正確處理資料夾不存在的異常情況

---

## 🔥 注意事項
- 後續需要逐步將下注頁、AI 頁、分析頁等模組改為統一透過 Session 存取資料
- 追加資料後必須手動 `Session.refresh("game_log")` 才能更新快取
- 目前 q_table 統一以 dict 結構處理（未來可擴充為支援更複雜的動作與特徵）

---

## 🔗 關聯 Issue
- Fixes #55 
