### PR TITLE
feat: 完成 entropy 分析模組與圖表輸出 (#82)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ Thumbs.db
 *.pkl
 *.svg
 *.json
+plots/*.png

--- a/Makefile
+++ b/Makefile
@@ -60,4 +60,8 @@ test_data_facade:
 	PYTHONPATH=$(PYTHONPATH) $(PYTHON)  ./tests/test_data_facade.py
 test_data_classifier:
 	PYTHONPATH=$(PYTHONPATH) $(PYTHON)  ./tests/test_data_classifier.py
+run_data_entropy_plotter:
+	PYTHONPATH=$(PYTHONPATH) $(PYTHON)  ./data/Analytics/entropy_plotter.py
+run_data_entropy_analyzer:
+	PYTHONPATH=$(PYTHONPATH) $(PYTHON)  ./data/Analytics/entropy_analyzer.py
 

--- a/agent/trainer.py
+++ b/agent/trainer.py
@@ -78,6 +78,13 @@ class QLearner:
             steps = 0
             fail_count = 0
             cumulative_reward = 0
+            row = df.iloc[idx]
+            state = self._get_state(row)
+            action = self._choose_action(state)
+            reward = self._get_reward(row, action)
+            next_idx = (idx + 1) % n_data
+            next_row = df.iloc[next_idx]
+            next_state = self._get_state(next_row)
 
             while steps < step_limit and fail_count < MAX_FAIL:
                 row = df.iloc[idx]
@@ -102,17 +109,17 @@ class QLearner:
 
                 idx = next_idx
                 steps += 1
-                q_values = np.array(self.q_table[state])
-                entropy = QLearner.calculate_entropy(q_values)
-
-                entropy_log.append({
-                    "round": idx - 1,
-                    "state": str(state),
-                    "entropy": entropy,
-                    "action": action,
-                    "reward": reward,
-                    "q_values": list(q_values),
-                })
+                # 在 while 結束後記錄 entropy（代表整輪）
+            q_values = np.array(self.q_table[state])
+            entropy = QLearner.calculate_entropy(q_values)
+            entropy_log.append({
+                "round": ep,
+                "state": str(state),
+                "entropy": entropy,
+                "action": action,
+                "reward": cumulative_reward,
+                "q_values": list(q_values),
+            })
 
 
         self.total_reward = cumulative_reward

--- a/data/Analytics/entropy_analyzer.py
+++ b/data/Analytics/entropy_analyzer.py
@@ -1,0 +1,114 @@
+# data/Analytics_page/entropy_analyzer.py
+
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+import matplotlib
+from pathlib import Path
+import numpy as np
+matplotlib.rc('font', family='Noto Serif CJK JP')
+
+
+# 預設 fuzzy 門檻
+DEFAULT_LOW_THRESH = 0.05
+DEFAULT_HIGH_THRESH = 0.3
+
+def load_entropy_data(path="logs/entropy_data.csv") -> pd.DataFrame:
+    df = pd.read_csv(path)
+    return df
+
+def assign_fuzzy_level(df: pd.DataFrame, low=DEFAULT_LOW_THRESH, high=DEFAULT_HIGH_THRESH) -> pd.DataFrame:
+    def fuzzify(e):
+        if e < low:
+            return "low"
+        elif e < high:
+            return "medium"
+        else:
+            return "high"
+    df["risk_level"] = df["entropy"].apply(fuzzify)
+    return df
+
+def plot_entropy_vs_reward(df: pd.DataFrame, save_path="plots/entropy_vs_reward.png"):
+    plt.figure(figsize=(8, 5))
+    sns.scatterplot(x="entropy", y="reward", data=df, alpha=0.5)
+    plt.title("Entropy vs Reward")
+    plt.xlabel("Entropy")
+    plt.ylabel("Reward")
+    plt.grid(True)
+    _save_plot(save_path)
+
+def plot_entropy_by_action(df: pd.DataFrame, save_path="plots/entropy_by_action.png"):
+    plt.figure(figsize=(6, 5))
+    sns.boxplot(x="action", y="entropy", data=df)
+    plt.title("Entropy 分佈（依據 Action）")
+    plt.xlabel("Action")
+    plt.ylabel("Entropy")
+    _save_plot(save_path)
+
+def plot_reward_by_entropy_level(df: pd.DataFrame, save_path="plots/reward_by_risk_level.png"):
+    plt.figure(figsize=(6, 5))
+    sns.boxplot(x="risk_level", y="reward", data=df, order=["low", "medium", "high"])
+    plt.title("Reward 分佈（依 fuzzy 風險等級）")
+    plt.xlabel("Fuzzy 風險等級")
+    plt.ylabel("Reward")
+    _save_plot(save_path)
+
+def plot_entropy_heatmap(df: pd.DataFrame, save_path="plots/entropy_heatmap.png"):
+    if "diff" not in df.columns or "rolling_sum_5" not in df.columns:
+        print("[WARN] 缺少 diff 或 rolling_sum_5 欄位，跳過熱圖")
+        return
+
+    pivot = df.groupby(["diff", "rolling_sum_5"])["entropy"].mean().unstack()
+    if pivot.empty:
+        print("[WARN] 熱圖資料為空，跳過畫圖")
+        return
+
+    plt.figure(figsize=(8, 6))
+    sns.heatmap(pivot, cmap="YlOrRd", annot=False)
+    plt.title("狀態平均 Entropy 熱圖")
+    plt.xlabel("rolling_sum_5")
+    plt.ylabel("diff")
+    _save_plot(save_path)
+
+def plot_entropy_sample_distribution(df: pd.DataFrame, save_path="plots/entropy_sample_distribution.png"):
+    df["entropy_bin"] = pd.cut(df["entropy"], bins=np.arange(0, 0.75, 0.05))
+    counts = df["entropy_bin"].value_counts().sort_index()
+
+    plt.figure(figsize=(8, 5))
+    counts.plot(kind="bar", color="skyblue")
+    plt.title("Entropy 區段樣本分佈圖")
+    plt.xlabel("Entropy 區間")
+    plt.ylabel("樣本數")
+    plt.xticks(rotation=45)
+    _save_plot(save_path)
+
+def summarize_entropy_by_state(df: pd.DataFrame, save_path="logs/state_entropy_summary.csv") -> pd.DataFrame:
+    df_state = df.groupby("state")["entropy"].mean().reset_index()
+    df_state.columns = ["state", "avg_entropy"]
+    df_state = df_state.sort_values("avg_entropy", ascending=False)
+    df_state.to_csv(save_path, index=False)
+    return df_state
+
+def _save_plot(path):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    plt.tight_layout()
+    plt.savefig(path)
+    print(f"[INFO] 圖片已儲存：{path}")
+    plt.close()
+
+def analyze_all():
+    df = load_entropy_data()
+    df = assign_fuzzy_level(df)
+
+    plot_entropy_vs_reward(df)
+    plot_entropy_by_action(df)
+    plot_reward_by_entropy_level(df)
+    plot_entropy_sample_distribution(df)
+    plot_entropy_heatmap(df)
+    summarize_entropy_by_state(df)
+
+    print("\n[INFO] Entropy 分析與圖表已完成。")
+
+if __name__ == "__main__":
+    analyze_all()
+

--- a/data/Analytics/entropy_plotter.py
+++ b/data/Analytics/entropy_plotter.py
@@ -1,0 +1,43 @@
+# data/Analytics_page/entropy_plotter.py
+
+import pandas as pd
+import matplotlib.pyplot as plt
+import matplotlib
+import seaborn as sns
+from pathlib import Path
+matplotlib.rc('font', family='Noto Serif CJK JP')
+
+def load_entropy_log(path="logs/entropy_data.csv") -> pd.DataFrame:
+    if not Path(path).exists():
+        raise FileNotFoundError(f"[ERROR] 找不到檔案：{path}")
+    df = pd.read_csv(path)
+    return df
+
+def plot_entropy_distribution(df: pd.DataFrame, save_path=None, show=True):
+    """畫出 entropy 的分佈圖（KDE + histogram）"""
+    if "entropy" not in df.columns:
+        raise ValueError("DataFrame 中找不到 entropy 欄位")
+
+    plt.figure(figsize=(10, 6))
+    sns.histplot(df["entropy"], kde=True, bins=40, color='skyblue', edgecolor='gray')
+
+    plt.title("Entropy 分佈圖", fontsize=14)
+    plt.xlabel("Entropy")
+    plt.ylabel("樣本數 / 機率密度")
+    plt.grid(True, linestyle="--", alpha=0.3)
+
+    if save_path:
+        Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+        plt.savefig(save_path)
+        print(f"[INFO] 圖片儲存於：{save_path}")
+
+    if show:
+        plt.show()
+
+def main():
+    df = load_entropy_log()
+    plot_entropy_distribution(df, save_path="plots/entropy_distribution.png")
+
+if __name__ == "__main__":
+    main()
+

--- a/data/models/model_log.json
+++ b/data/models/model_log.json
@@ -46,5 +46,17 @@
     "total_reward": 60,
     "max_drawdown": 640,
     "timestamp": "2025-05-01T11:41:59.443400"
+  },
+  {
+    "model_name": "q_model_0501_1324.pkl",
+    "episodes": 1000,
+    "epsilon": 0.9,
+    "alpha": 0.1,
+    "gamma": 0.95,
+    "roi": 0.01499531396438613,
+    "hit_rate": 0.757513277100906,
+    "total_reward": 240,
+    "max_drawdown": 600,
+    "timestamp": "2025-05-01T13:24:21.254216"
   }
 ]


### PR DESCRIPTION
- 建立 entropy_analyzer.py，實作 entropy 分析流程與多張圖表
- 含 KDE、Histogram、Boxplot、Heatmap、Reward 分佈、樣本分布等圖
- analyze_all() 可一鍵執行，並支援 CLI 測試

Closes #82
## ✅ 修改內容
- 建立 `entropy_analyzer.py`，模組化 entropy 分析與圖表流程
- 分析內容包括：
  - entropy KDE 分佈與 histogram
  - entropy vs reward 散佈圖
  - action 對應 entropy boxplot
  - fuzzy 分群下 reward boxplot
  - 熵值樣本分佈長條圖
  - 熱圖（diff × rolling_sum_5）
- 加入 analyze_all() 作為 CLI 入口
- 新增 .gitignore，排除 plots/*.png

## 📎 關聯任務
Closes #82
