### PR TITLE
Feature/build new qtabe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ test_data_facade:
 	PYTHONPATH=$(PYTHONPATH) $(PYTHON)  ./tests/test_data_facade.py
 test_data_classifier:
 	PYTHONPATH=$(PYTHONPATH) $(PYTHON)  ./tests/test_data_classifier.py
+test_q_table_manager:
+	PYTHONPATH=$(PYTHONPATH) $(PYTHON)  ./tests/test_q_table_manager.py
+	PYTHONPATH=$(PYTHONPATH) pytest ./tests/test_q_table_manager.py
 run_data_entropy_plotter:
 	PYTHONPATH=$(PYTHONPATH) $(PYTHON)  ./data/Analytics/entropy_plotter.py
 run_data_entropy_analyzer:

--- a/core/q_table_manager.py
+++ b/core/q_table_manager.py
@@ -1,0 +1,46 @@
+# core/q_table_manager.py
+
+import pandas as pd
+from typing import List, Tuple
+
+class QTableManager:
+    def __init__(self):
+        self.q_table = None
+        self.meta = {}
+    def init_q_table_from_range(self, diff_range: range, rsum_range: range, n_actions: int) -> pd.DataFrame:
+        states = [(d, r) for d in diff_range for r in rsum_range]
+        return self.init_q_table(states, n_actions)
+    def init_q_table(self, states: List[Tuple[int, int]], n_actions: int) -> pd.DataFrame:
+        self.q_table = pd.DataFrame(
+            0.0, 
+            index=pd.MultiIndex.from_tuples(states, names=["diff", "rsum"]),
+            columns=range(n_actions)
+        )
+        self.meta = {
+            "version": "2.0b",
+            "n_actions": n_actions,
+            "n_states": len(states),
+        }
+        return self.q_table
+    def from_dict(self, q_dict: dict, n_actions: int = None) -> pd.DataFrame:
+        """手動轉換 dict → MultiIndex DataFrame"""
+        if not q_dict:
+            raise ValueError("q_dict 為空，無法轉換成 Q 表")
+
+        index = list(q_dict.keys())
+        data = list(q_dict.values())
+
+        if n_actions is None:
+            first_row = data[0]
+            if not isinstance(first_row, (list, tuple)):
+                raise ValueError("q_dict 的值應為 list 或 tuple")
+            n_actions = len(first_row)
+
+        df = pd.DataFrame(data, index=pd.MultiIndex.from_tuples(index, names=["diff", "rsum"]))
+        df.columns = list(range(n_actions))
+        self.q_table = df
+        return df
+
+
+
+

--- a/core/q_table_manager.py
+++ b/core/q_table_manager.py
@@ -1,18 +1,20 @@
-# core/q_table_manager.py
-
 import pandas as pd
 from typing import List, Tuple
+from pathlib import Path
+from datetime import datetime
 
 class QTableManager:
     def __init__(self):
         self.q_table = None
         self.meta = {}
+
     def init_q_table_from_range(self, diff_range: range, rsum_range: range, n_actions: int) -> pd.DataFrame:
         states = [(d, r) for d in diff_range for r in rsum_range]
         return self.init_q_table(states, n_actions)
+
     def init_q_table(self, states: List[Tuple[int, int]], n_actions: int) -> pd.DataFrame:
         self.q_table = pd.DataFrame(
-            0.0, 
+            0.0,
             index=pd.MultiIndex.from_tuples(states, names=["diff", "rsum"]),
             columns=range(n_actions)
         )
@@ -20,8 +22,10 @@ class QTableManager:
             "version": "2.0b",
             "n_actions": n_actions,
             "n_states": len(states),
+            "created_at": datetime.now().isoformat()
         }
         return self.q_table
+
     def from_dict(self, q_dict: dict, n_actions: int = None) -> pd.DataFrame:
         """手動轉換 dict → MultiIndex DataFrame"""
         if not q_dict:
@@ -41,6 +45,18 @@ class QTableManager:
         self.q_table = df
         return df
 
+    def save(self, path: Path):
+        if self.q_table is None:
+            raise ValueError("尚未建立 Q 表，無法儲存")
+        self.q_table.to_pickle(path.with_suffix(".pkl"))
+        pd.Series(self.meta).to_json(path.with_name(path.stem + "_meta.json"))
 
-
+    def load(self, pkl_path: Path) -> pd.DataFrame:
+        self.q_table = pd.read_pickle(pkl_path)
+        meta_path = pkl_path.with_name(pkl_path.stem + "_meta.json")
+        if meta_path.exists():
+            self.meta = pd.read_json(meta_path, typ='series').to_dict()
+        else:
+            self.meta = {}
+        return self.q_table
 

--- a/data/global_data.py
+++ b/data/global_data.py
@@ -17,7 +17,9 @@ class Session:
                 cls._cache[key] = DATA_FACADE.game_log()
             elif key == "q_table":
                 model_name = kwargs.get("model_name", CONFIG.get("default_model", "q_model_0425_2023.pkl"))
-                cls._cache[key] = DATA_FACADE.q_table(model_name)
+                raw_q = DATA_FACADE.q_table(model_name)
+                q_table = QTableManager().from_dict(raw_q)
+                cls._cache[key] = q_table
             else:
                 raise KeyError(f"未知資料類型 {key}")
         return cls._cache[key]

--- a/tests/test_q_table_manager.py
+++ b/tests/test_q_table_manager.py
@@ -1,7 +1,28 @@
 import pytest
 import pandas as pd
 from core.q_table_manager import QTableManager
+import tempfile
+from pathlib import Path
 
+def test_q_table_save_and_load():
+    # 建立暫存資料夾（不影響專案內檔案）
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        file_path = tmp_path / "q_model_0501_1440.pkl"
+
+        # 初始化並儲存 Q 表
+        manager1 = QTableManager()
+        df1 = manager1.init_q_table_from_range(range(2), range(2), 2)
+        manager1.save(file_path)
+
+        # 使用另一個實例讀回
+        manager2 = QTableManager()
+        df2 = manager2.load(file_path)
+
+        # 確認內容一致
+        assert df1.equals(df2)
+        assert manager2.meta["n_actions"] == 2
+        assert manager2.meta["n_states"] == 4
 def test_init_q_table():
     manager = QTableManager()
     states = [(0, 0), (0, 1), (1, 0)]
@@ -88,6 +109,7 @@ if __name__ == "__main__":
     test_from_dict_empty()
     test_multiple_q_tables_with_different_shapes()
     test_from_dict_multiple_variants()
+    test_q_table_save_and_load()
 
     print("✅ 所有測試通過！")
 

--- a/tests/test_q_table_manager.py
+++ b/tests/test_q_table_manager.py
@@ -1,0 +1,94 @@
+import pytest
+import pandas as pd
+from core.q_table_manager import QTableManager
+
+def test_init_q_table():
+    manager = QTableManager()
+    states = [(0, 0), (0, 1), (1, 0)]
+    df = manager.init_q_table(states, 2)
+
+    assert isinstance(df, pd.DataFrame)
+    assert df.shape == (3, 2)
+    assert df.index.names == ["diff", "rsum"]
+    assert all(col in df.columns for col in [0, 1])
+    assert (df.values == 0.0).all()
+
+def test_init_q_table_from_range():
+    manager = QTableManager()
+    df = manager.init_q_table_from_range(range(2), range(3), 2)
+
+    assert df.shape == (6, 2)  # 2 x 3 狀態組合
+    assert df.index.names == ["diff", "rsum"]
+    assert (df.values == 0.0).all()
+
+def test_from_dict_auto_detect_n_actions():
+    q_dict = {
+        (0, 0): [0.1, 0.2],
+        (1, 0): [0.3, 0.4],
+    }
+    manager = QTableManager()
+    df = manager.from_dict(q_dict)
+
+    assert isinstance(df, pd.DataFrame)
+    assert df.shape == (2, 2)
+    assert list(df.loc[(0, 0)]) == [0.1, 0.2]
+    assert list(df.loc[(1, 0)]) == [0.3, 0.4]
+
+def test_from_dict_empty():
+    manager = QTableManager()
+    with pytest.raises(ValueError):
+        manager.from_dict({})
+
+def test_multiple_q_tables_with_different_shapes():
+    manager = QTableManager()
+
+    # 第一組 Q 表：3 states, 2 actions
+    states1 = [(0, 0), (0, 1), (1, 0)]
+    df1 = manager.init_q_table(states1, 2)
+    assert df1.shape == (3, 2)
+    assert (df1.values == 0.0).all()
+
+    # 第二組 Q 表：6 states, 3 actions
+    states2 = [(x, y) for x in range(2) for y in range(3)]
+    df2 = manager.init_q_table(states2, 3)
+    assert df2.shape == (6, 3)
+    assert (df2.values == 0.0).all()
+
+    # 確認 q_table 內容已被更新為第二組
+    assert manager.q_table.equals(df2)
+
+    # 驗證 meta 更新正確
+    assert manager.meta["n_actions"] == 3
+    assert manager.meta["n_states"] == 6
+
+def test_from_dict_multiple_variants():
+    manager = QTableManager()
+
+    q_dict_2a = {
+        (0, 0): [0.5, -0.2],
+        (0, 1): [0.1, 0.9],
+    }
+    df_2a = manager.from_dict(q_dict_2a)
+    assert df_2a.shape == (2, 2)
+
+    q_dict_3a = {
+        (0, 0): [0.1, 0.2, 0.3],
+        (1, 1): [-1.0, 0.0, 1.0],
+    }
+    df_3a = manager.from_dict(q_dict_3a)
+    assert df_3a.shape == (2, 3)
+
+    # 再次確認 from_dict 不會殘留舊內容
+    assert manager.q_table.equals(df_3a)
+    assert list(df_3a.columns) == [0, 1, 2]
+if __name__ == "__main__":
+    test_init_q_table()
+    test_init_q_table_from_range()
+    test_from_dict_auto_detect_n_actions()
+    test_from_dict_empty()
+    test_multiple_q_tables_with_different_shapes()
+    test_from_dict_multiple_variants()
+
+    print("✅ 所有測試通過！")
+
+


### PR DESCRIPTION
- [x] 建立 `QTableManager` 類別（methods: load/save/init/meta）
- [x] 實作 `init_q_table(states, n_actions)` 建立空 Q 表（MultiIndex）
- [x] 儲存時產生 `.pkl` + `.meta.json` 組合
- [x] 撰寫 `load_q_table(path)` 可自動讀取 DataFrame 與 meta
- [x] 測試與 AIPredictor `_safe_slice()` 相容性
- [x] 撰寫單元測試涵蓋初始化、存取、格式轉換等邏輯
Closes #98 